### PR TITLE
Build version 0.5.4

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "CommonMark" %}
-{% set version = "0.7.3" %}
-{% set sha256 = "5f20ebd91614c8d339d4cded314894feb5d9a54c3b52c1ff9883794557149ea8" %}
+{% set version = "0.5.4" %}
+{% set sha256 = "34d73ec8085923c023930dfc0bcd1c4286e28a2a82de094bb72fabcc0281cbe5" %}
 
 package:
   name: {{ name | lower }}


### PR DESCRIPTION
commonmark 0.5.4 is needed for the current recommonmark 0.4.0 release.