### PR TITLE
Build version 0.5.4

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
 build:
   noarch: python
   number: 0
-  script: python setup.py install --single-version-externally-managed --record record.txt
+  script: pip install --no-use-wheel --ignore-installed --no-deps .
   entry_points:
     - cmark = CommonMark.cmark:main
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
 build:
   noarch: python
   number: 0
-  script: pip install --no-use-wheel --ignore-installed --no-deps .
+  script: pip install -v --no-binary :all: --ignore-installed --no-deps .
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,8 +15,6 @@ build:
   noarch: python
   number: 0
   script: pip install --no-use-wheel --ignore-installed --no-deps .
-  entry_points:
-    - cmark = CommonMark.cmark:main
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "CommonMark" %}
-{% set version = "0.7.4" %}
-{% set sha256 = "24678b72094398df96312fb927e274ccaf5148f25e47aca9f7fc062693ae7577" %}
+{% set version = "0.5.4" %}
+{% set sha256 = "34d73ec8085923c023930dfc0bcd1c4286e28a2a82de094bb72fabcc0281cbe5" %}
 
 package:
   name: {{ name | lower }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
 build:
   noarch: python
   number: 0
-  script: pip install -v --no-binary :all: --ignore-installed --no-deps .
+  script: "pip install -v --no-binary :all: --ignore-installed --no-deps ."
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,8 +29,8 @@ test:
   source_files:
     - spec.txt
 
-  imports:
-    - CommonMark
+#  imports:
+#    - CommonMark
 
   requires:
     - flake8

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,18 +31,13 @@ test:
 
   imports:
     - CommonMark
-    - CommonMark.render
-    - CommonMark.tests
 
   requires:
     - flake8
     - hypothesis
 
   commands:
-    - python -m CommonMark.tests.unit_tests
-    # Fails on windows due to some encoding issue
-    - python -m CommonMark.tests.run_spec_tests  # [not win]
-    - cmark --help
+    - cmark.py --help
 
 about:
   home: http://commonmark.org/


### PR DESCRIPTION
commonmark 0.5.4 is needed for the current recommonmark 0.4.0 release.

Supersedes #5.