### PR TITLE
CommonMark 0.5.4

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "CommonMark" %}
-{% set version = "0.7.4" %}
-{% set sha256 = "24678b72094398df96312fb927e274ccaf5148f25e47aca9f7fc062693ae7577" %}
+{% set version = "0.5.4" %}
+{% set sha256 = "34d73ec8085923c023930dfc0bcd1c4286e28a2a82de094bb72fabcc0281cbe5" %}
 
 package:
   name: {{ name | lower }}
@@ -14,14 +14,13 @@ source:
 build:
   noarch: python
   number: 1
-  script: python setup.py install --single-version-externally-managed --record record.txt
-  entry_points:
-    - cmark = CommonMark.cmark:main
+  script: "python -m pip install -v --no-binary :all: --no-deps --ignore-installed ."
 
 requirements:
   build:
     - python
     - setuptools
+    - pip
 
   run:
     - python
@@ -33,18 +32,6 @@ test:
 
   imports:
     - CommonMark
-    - CommonMark.render
-    - CommonMark.tests
-
-  requires:
-    - flake8
-    - hypothesis
-
-  commands:
-    - python -m CommonMark.tests.unit_tests
-    # Fails on windows due to some encoding issue
-    - python -m CommonMark.tests.run_spec_tests  # [not win]
-    - cmark --help
 
 about:
   home: http://commonmark.org/


### PR DESCRIPTION
It turns out that the conda-forge package that was built in #6 (https://anaconda.org/conda-forge/commonmark/0.5.4/download/noarch/commonmark-0.5.4-py_0.tar.bz2) does not have the python files, for some reason. So we're trying this again...
  